### PR TITLE
Correct apt:sources for ubuntu-toolchain-r-test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,15 +7,22 @@
 # FMS is not a c-language project, although there are a few c-language
 # sources.  However, this is the best choice.
 language: c
+os: linux
 dist: bionic
-sudo: false
 
 addons:
   apt:
     sources:
-    - ubuntu-toolchain-r-test
+    - sourceline: 'ppa:ubuntu-toolchain-r/test'
     packages:
-    - pkg-config gfortran netcdf-bin libnetcdf-dev libnetcdff-dev openmpi-bin libopenmpi-dev 
+    - pkg-config 
+    - netcdf-bin 
+    - libnetcdf-dev 
+    - libnetcdff-dev 
+    - openmpi-bin 
+    - libopenmpi-dev 
+    - gfortran
+
 # Travis sets CC to gcc, but we need to ensure it is not set, so we can use mpicc
 before_install:
   - test -n "$CC" && unset CC


### PR DESCRIPTION
Travis is throwing an error that it cannot use the source ubuntu-toolchain-r-test.  This update corrects that with by using sourceline option for apt:sources.