### PR TITLE
Subaxis2 for issue #409

### DIFF
--- a/diag_manager/diag_output.F90
+++ b/diag_manager/diag_output.F90
@@ -212,7 +212,10 @@ CONTAINS
         if (.not.check_if_open(fileob)) then
                call open_check(open_file(fileobjND, trim(fname_no_tile)//".nc."//trim(mype_string), "overwrite", &
                             nc_format="64bit", is_restart=.false.))
-        endif
+               !< For regional subaxis add the NumFilesInSet attribute, which is added by fms2_io for (other)
+               !< domains with sufficient decomposition info. Note mppnccombine will work with an entry of zero.
+               call register_global_attribute(fileobjND, "NumFilesInSet", 0)
+       endif
        fnum_domain = "nd" ! no domain
        if (file_unit < 0) file_unit = 10
      endiF
@@ -401,12 +404,8 @@ integer :: domain_size, axis_length, axis_pos
                               case (-1)
                                    call register_variable_attribute(fptr, axis_name, "positive", "down")
                          end select
-                         !< For regional subaxis add the NumFilesInSet and domain_decomposition atibutes, which
-                         !< are automatically added by fms2_io for (other) domains for which it has sufficient
-                         !< decomposition info. Note mppnccombine will work with an entry of zero.
-                         if (.not. global_att_exists(fptr,"NumFilesInSet")) then
-                            call register_global_attribute(fptr, "NumFilesInSet", 0)
-                         endif
+                         !< For regional subaxis add the "domain_decomposition" attribute, which is added
+                         !< fms2_io for (other) domains with sufficient decomposition info.
                          call register_variable_attribute(fptr, axis_name, "domain_decomposition", &
                               (/gstart, gend, cstart, cend/))
                          call write_data(fptr, axis_name, axis_data(istart:iend) )

--- a/diag_manager/diag_output.F90
+++ b/diag_manager/diag_output.F90
@@ -212,9 +212,6 @@ CONTAINS
         if (.not.check_if_open(fileob)) then
                call open_check(open_file(fileobjND, trim(fname_no_tile)//".nc."//trim(mype_string), "overwrite", &
                     nc_format="64bit", is_restart=.false.))
-               !< For regional subaxis add the NumFilesInSet, which is automatically added by fms2_io for other 
-               !< domains for which it has sufficient decomposition info. mppnccombine will work with an entry of zero.
-               call register_global_attribute(fileobjND, "NumFilesInSet", 0)
         endif
        fnum_domain = "nd" ! no domain
        if (file_unit < 0) file_unit = 10
@@ -404,11 +401,15 @@ integer :: domain_size, axis_length, axis_pos
                               case (-1)
                                    call register_variable_attribute(fptr, axis_name, "positive", "down")
                          end select
-                         !< For regional subaxis add the domain_decomposition, which is automatically added by fms2_io
-                         !< for other domains for which it has sufficient decomposition info..
+                         !< For regional subaxis add the NumFilesInSet and domain_decomposition atibutes, which
+                         !< are automatically added by fms2_io for (other) domains for which it has sufficient
+                         !< decomposition info. Note mppnccombine will work with an entry of zero.
+                         if (.not. global_att_exists(fptr,"NumFilesInSet")) then
+                            call register_global_attribute(fptr, "NumFilesInSet", 0)
+                         endif
                          call register_variable_attribute(fptr, axis_name, "domain_decomposition", &
-                                        (/gstart, gend, cstart, cend/))
-                                
+                              (/gstart, gend, cstart, cend/))
+                         
                          call write_data(fptr, axis_name, axis_data(istart:iend) )
                     class default
                          call error_mesg("diag_output_mod::write_axis_meta_data", &

--- a/diag_manager/diag_output.F90
+++ b/diag_manager/diag_output.F90
@@ -212,6 +212,7 @@ CONTAINS
         if (.not.check_if_open(fileob)) then
                call open_check(open_file(fileobjND, trim(fname_no_tile)//".nc."//trim(mype_string), "overwrite", &
                             nc_format="64bit", is_restart=.false.))
+               call register_global_attribute(fileobjND, "NumFilesInSet", 0)
         endif
        fnum_domain = "nd" ! no domain
        if (file_unit < 0) file_unit = 10
@@ -386,7 +387,7 @@ integer :: domain_size, axis_length, axis_pos
                          call write_data(fptr, axis_name, axis_data(istart:iend) )
                       endif
                     type is (FmsNetcdfFile_t) !< For regional X and Y axes, treat as any other axis
-                         call mpp_get_global_domain(domain, begin=gstart)  !< Get the global indicies
+                         call mpp_get_global_domain(domain, begin=gstart, end=gend)  !< Get the global indicies
                          call mpp_get_compute_domain(domain, begin=cstart, end=cend, size=clength) !< Get the compute indicies
                          iend =  cend - gstart + 1     !< Get the array indicies for the axis data
                          istart = cstart - gstart + 1 
@@ -401,6 +402,9 @@ integer :: domain_size, axis_length, axis_pos
                               case (-1)
                                    call register_variable_attribute(fptr, axis_name, "positive", "down")
                          end select
+                         call register_variable_attribute(fptr, axis_name, "domain_decomposition", &
+                                        (/gstart, gend, cstart, cend/))
+                                
                          call write_data(fptr, axis_name, axis_data(istart:iend) )
                     class default
                          call error_mesg("diag_output_mod::write_axis_meta_data", &

--- a/diag_manager/diag_output.F90
+++ b/diag_manager/diag_output.F90
@@ -211,7 +211,9 @@ CONTAINS
        write(mype_string,'(I0.4)') mype
         if (.not.check_if_open(fileob)) then
                call open_check(open_file(fileobjND, trim(fname_no_tile)//".nc."//trim(mype_string), "overwrite", &
-                            nc_format="64bit", is_restart=.false.))
+                    nc_format="64bit", is_restart=.false.))
+               !< For regional subaxis add the NumFilesInSet, which is automatically added by fms2_io for other 
+               !< domains for which it has sufficient decomposition info. mppnccombine will work with an entry of zero.
                call register_global_attribute(fileobjND, "NumFilesInSet", 0)
         endif
        fnum_domain = "nd" ! no domain
@@ -402,6 +404,8 @@ integer :: domain_size, axis_length, axis_pos
                               case (-1)
                                    call register_variable_attribute(fptr, axis_name, "positive", "down")
                          end select
+                         !< For regional subaxis add the domain_decomposition, which is automatically added by fms2_io
+                         !< for other domains for which it has sufficient decomposition info..
                          call register_variable_attribute(fptr, axis_name, "domain_decomposition", &
                                         (/gstart, gend, cstart, cend/))
                                 


### PR DESCRIPTION
**Description**
Fixes errors in writing regional diagnostics using mask tables by registering global attribute "NumFilesInSet" and per-axis attribute "domain_decomposition" for regional X and Y axis.
NumFilesInSet is always set equal to 0.

Fixes # 409

**How Has This Been Tested?**
Ocean model output  for regional diagnostic with mask tables were performed on Xanadu and 2020.02 code base (plus this fix) and compared.

**Checklist:**
- [ X] My code follows the style guidelines of this project
- [ X] I have performed a self-review of my own code
- [ X] I have commented my code, particularly in hard-to-understand areas
- [ X] I have made corresponding changes to the documentation
- [ X] My changes generate no new warnings
- [ X] Any dependent changes have been merged and published in downstream modules
- [ X] New check tests, if applicable, are included
- [ X] `make distcheck` passes

